### PR TITLE
Fixing bug when adding review, not updating reviewIds

### DIFF
--- a/src/main/java/dev/farhan/movieist/movies/ReviewService.java
+++ b/src/main/java/dev/farhan/movieist/movies/ReviewService.java
@@ -22,9 +22,8 @@ public class ReviewService {
 
         mongoTemplate.update(Movie.class)
             .matching(Criteria.where("imdbId").is(imdbId))
-            .apply(new Update().push("reviews").value(review))
-            .first();
-
+                .apply(new Update().push("reviewIds").value(review.getId()))
+                .first();
         return review;
     }
 }


### PR DESCRIPTION
In your video tutorial at point https://youtu.be/5PdEmeopJVQ?t=5077 you mention that we should update "reviewIds" array but there is an inconsistency with the github repo code of same file where you update "reviews" array which does not exists and is being created and it stores whole review object instead of only review's id.

There are even some Youtube users complaining about this error and I thought I could fix it.

Kinds regards and thanks for the tutorial.